### PR TITLE
Added a test to prevent processing nil customize for build_vb_customize

### DIFF
--- a/lib/chef/knife/vagrant_server_create.rb
+++ b/lib/chef/knife/vagrant_server_create.rb
@@ -197,7 +197,7 @@ class Chef
       end
 
       def build_vb_customize(customize)
-        customize.split(/::/).collect { |k| "vb.customize [ #{k} ]" }.join("\n")
+        customize.split(/::/).collect { |k| "vb.customize [ #{k} ]" }.join("\n") if customize
       end
 
       def build_shares(share_folders)


### PR DESCRIPTION
If there is no vb customize, the run errors out. Added a test to prevent that.

Example of failure:

```
knife vagrant server create -b opscode_debian-7.2.0_chef-provisionerless -N "target1" -m 512 -VV
Instance name: target1
Instance IP: 192.168.67.2
Box: opscode_debian-7.2.0_chef-provisionerless

Launching instance
/Users/rberger/.rvm/gems/ruby-1.9.3-p484@chef_fundamentals/gems/knife-vagrant2-0.0.2/lib/chef/knife/vagrant_server_create.rb:200:in `build_vb_customize': undefined method `split' for nil:NilClass (NoMethodError)
    from /Users/rberger/.rvm/gems/ruby-1.9.3-p484@chef_fundamentals/gems/knife-vagrant2-0.0.2/lib/chef/knife/vagrant_server_create.rb:229:in `write_vagrantfile'
    from /Users/rberger/.rvm/gems/ruby-1.9.3-p484@chef_fundamentals/gems/knife-vagrant2-0.0.2/lib/chef/knife/vagrant_server_create.rb:175:in `run'
    from /Users/rberger/.rvm/gems/ruby-1.9.3-p484@chef_fundamentals/gems/chef-11.8.2/lib/chef/knife.rb:485:in `run_with_pretty_exceptions'
```
