### PR TITLE
Fix 2 issues

### DIFF
--- a/lib/chef/knife/vagrant_server_create.rb
+++ b/lib/chef/knife/vagrant_server_create.rb
@@ -6,6 +6,7 @@ class Chef
 
       include Knife::VagrantBase
       deps do
+        require 'ostruct'
         require 'ipaddr'
         require 'chef/knife/bootstrap'
         Chef::Knife::Bootstrap.load_deps
@@ -94,6 +95,7 @@ class Chef
         :short => "-d DISTRO",
         :long => "--distro DISTRO",
         :description => "Bootstrap a distro using a template; default is 'chef-full'",
+        :default => 'chef-full',
         :proc => Proc.new { |d| Chef::Config[:knife][:distro] = d }
 
       option :template_file,


### PR DESCRIPTION
The default working folder was changed to .vagrant to be similar to how other tooling handle temporary work directories. Also fixed 2 other issues that arose when doing a clean gem install.

-M
