### PR TITLE
Add vagrant 1.7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.7 (unreleased) 
+## Changes and new features 
+
+*Added support for vagrant 1.7 private_key files instead of the default insecure key
+
 # 0.0.6 (unreleased)
 
 ## Changes and new features

--- a/lib/knife-vagrant/version.rb
+++ b/lib/knife-vagrant/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Vagrant
-    VERSION = "0.0.6"
+    VERSION = "0.0.7"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end


### PR DESCRIPTION
PR checks the vagrant version on the machine and if 1.7 or higher uses the new private_key file generated by vagrant instead of the insecure_key that was previously used. I've tested this against our project with both vagrant (with virutalbox provider) 1.7.1 and 1.6.5 and observed correct behavior. 

Extra eyes on the provider logic is probably worthwhile as I'm not sure that vagrant uses the same directory layout for each provider (I confirmed the structure for fusion and virtualbox), nor am I sure if the  :chef_node_name directory always contains only one vm. 

Great tool, thank you for it. 
Josh
