### PR TITLE
fixed incorrect parsing of vmx config parameters

### DIFF
--- a/lib/chef/knife/vagrant_server_create.rb
+++ b/lib/chef/knife/vagrant_server_create.rb
@@ -219,7 +219,7 @@ class Chef
       end
 
       def build_vmx_customize(customize)
-        customize.split(/::/).collect { |k| "v.vmx [ #{k} ]" }.join("\n") if customize
+        customize.split(/::/).collect { |k| "v.vmx[#{k.split(/=/)[0]}] = #{k.split(/=/)[1]}" }.join("\n") if customize
       end
 
       def build_shares(share_folders)


### PR DESCRIPTION
The vmx_customize is parsed and composed in the vagrantfile incorrectly.

The current logic composing the configuration similar to vb_customize, but for vmware the configuration syntax is different in the Vagrant file. For example the current code.

```
      def build_vmx_customize(customize)
        customize.split(/::/).collect { |k| "v.vmx [ #{k} ]" }.join("\n") if customize
      end
```

Will create the following if vmx_customize is `"numvcpus"="2"::"vhv.enable"="TRUE"::`.

```
Vagrant.configure("2") do |config|
.
.
config.vm.provider :vmware_workstation do |v|
  v.vmx["memsize"] = "512"
  v.vmx [ "numvcpus"="2" ]
  v.vmx [ "vhv.enable"="TRUE" ]
end
.
.
end
```

When what we really need is.

```
Vagrant.configure("2") do |config|
.
.
config.vm.provider :vmware_workstation do |v|
  v.vmx["memsize"] = "512"
  v.vmx["numvcpus"]="2"
  v.vmx["vhv.enable"]="TRUE"
end
.
.
end
```

The following change will correct the syntax.

```
      def build_vmx_customize(customize)
        customize.split(/::/).collect { |k| "v.vmx[#{k.split(/=/)[0]}] = #{k.split(/=/)[1]}" }.join("\n") if customize
      end
```
